### PR TITLE
Performance improvements by changing the way we keep track of solutions during pathfinding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /bin
 /obj
 /RoboRouter.csproj.user
+/.vscode
+settings.xml

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /RoboRouter.csproj.user
 /.vscode
 settings.xml
+/Release

--- a/AlgRunner.cs
+++ b/AlgRunner.cs
@@ -160,8 +160,8 @@ public class AlgRunner
         timer.Stop();
 
 
-        if (!settings.DisableSorting)
-            solutions = solutions.OrderByDescending(s => s.Item2).ToList();
+        //if (!settings.DisableSorting)
+        //    solutions = solutions.OrderByDescending(s => s.Item2).ToList();
         // normal console output
         if (!settings.LogResults)
             foreach (var sol in solutions) {

--- a/AlgRunner.cs
+++ b/AlgRunner.cs
@@ -58,7 +58,9 @@ public class AlgRunner
         int index = 0;
         int visitCount = 0;
 
-        const int topNSolutions = 10;
+        for (int i = 0; i < settings.topNSolutions; i++) {
+            solutions.Add(new(new int[] {}, 99999999));
+        }
 
         Func<int, bool, bool> canRestart;
         if (infRestarts) {
@@ -87,10 +89,14 @@ public class AlgRunner
                     var truncated = trail.Take(index + 1).ToArray();
                     int time = truncated.Skip(1).Select((e, i) => e == start ? restartPenalty : nodes[trail[i]].FramesTo(e)).Sum();
                     consideredSolutions++;
-                    solutions.Add(new(truncated, time));
-                    if (consideredSolutions > topNSolutions) {
-                        solutions.Sort((x, y) => y.Item2.CompareTo(x.Item2));
-                        solutions.RemoveAt(0);
+                    if (time < solutions[settings.topNSolutions - 1].Item2) {
+                        for (int i = 0; i < settings.topNSolutions; i++) {
+                            if (time < solutions[i].Item2) {
+                                solutions.Insert(i, new(truncated, time));
+                                solutions.RemoveAt(settings.topNSolutions);
+                                break;
+                            }
+                        }
                     }
                 }
                 return;
@@ -157,8 +163,8 @@ public class AlgRunner
             }
         }
 
+        solutions.Reverse();
         timer.Stop();
-
 
         //if (!settings.DisableSorting)
         //    solutions = solutions.OrderByDescending(s => s.Item2).ToList();

--- a/MainForm.Designer.cs
+++ b/MainForm.Designer.cs
@@ -41,6 +41,7 @@ namespace RoboRouter
             this.restartsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.onlyRequiredRestartsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.maxRestartCountToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.topNSolutionsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.lbl_startName = new System.Windows.Forms.Label();
             this.lbl_finishName = new System.Windows.Forms.Label();
             this.txt_startName = new System.Windows.Forms.TextBox();
@@ -148,10 +149,12 @@ namespace RoboRouter
             // 
             this.restartsToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.onlyRequiredRestartsToolStripMenuItem,
-            this.maxRestartCountToolStripMenuItem});
+            this.maxRestartCountToolStripMenuItem,
+            this.topNSolutionsToolStripMenuItem
+            });
             this.restartsToolStripMenuItem.Name = "restartsToolStripMenuItem";
             this.restartsToolStripMenuItem.Size = new System.Drawing.Size(60, 20);
-            this.restartsToolStripMenuItem.Text = "Restarts";
+            this.restartsToolStripMenuItem.Text = "Settings";
             // 
             // onlyRequiredRestartsToolStripMenuItem
             // 
@@ -165,6 +168,12 @@ namespace RoboRouter
             this.maxRestartCountToolStripMenuItem.Name = "maxRestartCountToolStripMenuItem";
             this.maxRestartCountToolStripMenuItem.Size = new System.Drawing.Size(196, 22);
             this.maxRestartCountToolStripMenuItem.Text = "Max Restart Count";
+            // 
+            // topNSolutionsToolStripMenuItem
+            // 
+            this.topNSolutionsToolStripMenuItem.Name = "topNSolutionsToolStripMenuItem";
+            this.topNSolutionsToolStripMenuItem.Size = new System.Drawing.Size(196, 22);
+            this.topNSolutionsToolStripMenuItem.Text = "Number of Solutions";
             // 
             // lbl_startName
             // 
@@ -335,6 +344,7 @@ namespace RoboRouter
         private System.Windows.Forms.ToolStripMenuItem logResultsToTextFilesToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem onlyRequiredRestartsToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem maxRestartCountToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem topNSolutionsToolStripMenuItem;
         private System.Windows.Forms.NumericUpDown num_restartPenalty;
         private System.Windows.Forms.Label lbl_restartPenalty;
         //private System.Windows.Forms.ToolStripMenuItem disableResultSortingToolStripMenuItem;

--- a/MainForm.Designer.cs
+++ b/MainForm.Designer.cs
@@ -35,7 +35,7 @@ namespace RoboRouter
             this.menuStrip1 = new System.Windows.Forms.MenuStrip();
             this.helpToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.outputToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.distinctResultEndTimesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            //this.distinctResultEndTimesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.logResultsToTextFilesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.disableResultSortingToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.restartsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -115,7 +115,7 @@ namespace RoboRouter
             // outputToolStripMenuItem
             // 
             this.outputToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.distinctResultEndTimesToolStripMenuItem,
+            //this.distinctResultEndTimesToolStripMenuItem,
             this.logResultsToTextFilesToolStripMenuItem,
             this.disableResultSortingToolStripMenuItem});
             this.outputToolStripMenuItem.Name = "outputToolStripMenuItem";
@@ -124,10 +124,10 @@ namespace RoboRouter
             // 
             // distinctResultEndTimesToolStripMenuItem
             // 
-            this.distinctResultEndTimesToolStripMenuItem.Name = "distinctResultEndTimesToolStripMenuItem";
-            this.distinctResultEndTimesToolStripMenuItem.Size = new System.Drawing.Size(206, 22);
-            this.distinctResultEndTimesToolStripMenuItem.Text = "Distinct Result End Times";
-            this.distinctResultEndTimesToolStripMenuItem.Click += new System.EventHandler(this.distinctResultEndTimesToolStripMenuItem_Click);
+            //this.distinctResultEndTimesToolStripMenuItem.Name = "distinctResultEndTimesToolStripMenuItem";
+            //this.distinctResultEndTimesToolStripMenuItem.Size = new System.Drawing.Size(206, 22);
+            //this.distinctResultEndTimesToolStripMenuItem.Text = "Distinct Result End Times";
+            //this.distinctResultEndTimesToolStripMenuItem.Click += new System.EventHandler(this.distinctResultEndTimesToolStripMenuItem_Click);
             // 
             // logResultsToTextFilesToolStripMenuItem
             // 
@@ -330,7 +330,7 @@ namespace RoboRouter
         private System.Windows.Forms.Label lbl_nameSeparators;
         private System.Windows.Forms.TextBox txt_nameSeparators;
         private System.Windows.Forms.Button btn_refresh;
-        private System.Windows.Forms.ToolStripMenuItem distinctResultEndTimesToolStripMenuItem;
+        //private System.Windows.Forms.ToolStripMenuItem distinctResultEndTimesToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem logResultsToTextFilesToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem onlyRequiredRestartsToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem maxRestartCountToolStripMenuItem;

--- a/MainForm.Designer.cs
+++ b/MainForm.Designer.cs
@@ -37,7 +37,7 @@ namespace RoboRouter
             this.outputToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             //this.distinctResultEndTimesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.logResultsToTextFilesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.disableResultSortingToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            //this.disableResultSortingToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.restartsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.onlyRequiredRestartsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.maxRestartCountToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -117,7 +117,8 @@ namespace RoboRouter
             this.outputToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             //this.distinctResultEndTimesToolStripMenuItem,
             this.logResultsToTextFilesToolStripMenuItem,
-            this.disableResultSortingToolStripMenuItem});
+            //this.disableResultSortingToolStripMenuItem
+            });
             this.outputToolStripMenuItem.Name = "outputToolStripMenuItem";
             this.outputToolStripMenuItem.Size = new System.Drawing.Size(57, 20);
             this.outputToolStripMenuItem.Text = "Output";
@@ -138,10 +139,10 @@ namespace RoboRouter
             // 
             // disableResultSortingToolStripMenuItem
             // 
-            this.disableResultSortingToolStripMenuItem.Name = "disableResultSortingToolStripMenuItem";
-            this.disableResultSortingToolStripMenuItem.Size = new System.Drawing.Size(206, 22);
-            this.disableResultSortingToolStripMenuItem.Text = "Disable Result Sorting";
-            this.disableResultSortingToolStripMenuItem.Click += new System.EventHandler(this.disableResultSortingToolStripMenuItem_Click);
+            //this.disableResultSortingToolStripMenuItem.Name = "disableResultSortingToolStripMenuItem";
+            //this.disableResultSortingToolStripMenuItem.Size = new System.Drawing.Size(206, 22);
+            //this.disableResultSortingToolStripMenuItem.Text = "Disable Result Sorting";
+            //this.disableResultSortingToolStripMenuItem.Click += new System.EventHandler(this.disableResultSortingToolStripMenuItem_Click);
             // 
             // restartsToolStripMenuItem
             // 
@@ -336,6 +337,6 @@ namespace RoboRouter
         private System.Windows.Forms.ToolStripMenuItem maxRestartCountToolStripMenuItem;
         private System.Windows.Forms.NumericUpDown num_restartPenalty;
         private System.Windows.Forms.Label lbl_restartPenalty;
-        private System.Windows.Forms.ToolStripMenuItem disableResultSortingToolStripMenuItem;
+        //private System.Windows.Forms.ToolStripMenuItem disableResultSortingToolStripMenuItem;
     }
 }

--- a/MainForm.cs
+++ b/MainForm.cs
@@ -25,6 +25,7 @@ public partial class MainForm : Form
     {
         InitializeComponent();
         maxRestarts = new NumMenuItem(maxRestartCountToolStripMenuItem, -1, 1000, 0);
+        topNSolutions = new NumMenuItem(topNSolutionsToolStripMenuItem, 1, 1000, 0);
 
         LoadSettings();
         ParseFiles(false);
@@ -238,6 +239,7 @@ public partial class MainForm : Form
     }
 
     NumMenuItem maxRestarts;
+    NumMenuItem topNSolutions;
 
     SettingsManager manager;
 

--- a/MainForm.cs
+++ b/MainForm.cs
@@ -311,7 +311,7 @@ public partial class MainForm : Form
     private void onlyRequiredRestartsToolStripMenuItem_Click(object sender, EventArgs e) => onlyRequiredRestartsToolStripMenuItem.Checked ^= true;
     //private void distinctResultEndTimesToolStripMenuItem_Click(object sender, EventArgs e) => distinctResultEndTimesToolStripMenuItem.Checked ^= true;
     private void logResultsToTextFilesToolStripMenuItem_Click(object sender, EventArgs e) => logResultsToTextFilesToolStripMenuItem.Checked ^= true;
-    private void disableResultSortingToolStripMenuItem_Click(object sender, EventArgs e) => disableResultSortingToolStripMenuItem.Checked ^= true;
+    //private void disableResultSortingToolStripMenuItem_Click(object sender, EventArgs e) => disableResultSortingToolStripMenuItem.Checked ^= true;
 
     private void cbx_useTableInput_CheckedChanged(object sender, EventArgs e) => UpdateAccess();
 

--- a/MainForm.cs
+++ b/MainForm.cs
@@ -309,7 +309,7 @@ public partial class MainForm : Form
     }
 
     private void onlyRequiredRestartsToolStripMenuItem_Click(object sender, EventArgs e) => onlyRequiredRestartsToolStripMenuItem.Checked ^= true;
-    private void distinctResultEndTimesToolStripMenuItem_Click(object sender, EventArgs e) => distinctResultEndTimesToolStripMenuItem.Checked ^= true;
+    //private void distinctResultEndTimesToolStripMenuItem_Click(object sender, EventArgs e) => distinctResultEndTimesToolStripMenuItem.Checked ^= true;
     private void logResultsToTextFilesToolStripMenuItem_Click(object sender, EventArgs e) => logResultsToTextFilesToolStripMenuItem.Checked ^= true;
     private void disableResultSortingToolStripMenuItem_Click(object sender, EventArgs e) => disableResultSortingToolStripMenuItem.Checked ^= true;
 

--- a/RoboRouter.csproj
+++ b/RoboRouter.csproj
@@ -6,6 +6,7 @@
     <Nullable>enable</Nullable>
     <UseWindowsForms>true</UseWindowsForms>
     <ImplicitUsings>enable</ImplicitUsings>
+    <PublishSingleFile>true</PublishSingleFile>
   </PropertyGroup>
 
 </Project>

--- a/RoboRouter.csproj
+++ b/RoboRouter.csproj
@@ -7,6 +7,7 @@
     <UseWindowsForms>true</UseWindowsForms>
     <ImplicitUsings>enable</ImplicitUsings>
     <PublishSingleFile>true</PublishSingleFile>
+    <Optimize>true</Optimize>
   </PropertyGroup>
 
 </Project>

--- a/Settings.cs
+++ b/Settings.cs
@@ -21,6 +21,8 @@ public class Settings
     public bool RequiredRestarts = true;
     [Setting(Input = "maxRestarts.Value")]
     public int maxRestarts = -1;
+    [Setting(Input = "topNSolutions.Value")]
+    public int topNSolutions = 100;
 
     // [Setting(Input = "distinctResultEndTimesToolStripMenuItem.Checked")]
     // public bool DistinctTimings = true;

--- a/Settings.cs
+++ b/Settings.cs
@@ -26,8 +26,8 @@ public class Settings
     // public bool DistinctTimings = true;
     [Setting(Input = "logResultsToTextFilesToolStripMenuItem.Checked")]
     public bool LogResults = false;
-    [Setting(Input = "disableResultSortingToolStripMenuItem.Checked")]
-    public bool DisableSorting = false;
+    //[Setting(Input = "disableResultSortingToolStripMenuItem.Checked")]
+    //public bool DisableSorting = false;
 
     public bool KnowsHelpTxt = false;
 }

--- a/Settings.cs
+++ b/Settings.cs
@@ -22,8 +22,8 @@ public class Settings
     [Setting(Input = "maxRestarts.Value")]
     public int maxRestarts = -1;
 
-    [Setting(Input = "distinctResultEndTimesToolStripMenuItem.Checked")]
-    public bool DistinctTimings = true;
+    // [Setting(Input = "distinctResultEndTimesToolStripMenuItem.Checked")]
+    // public bool DistinctTimings = true;
     [Setting(Input = "logResultsToTextFilesToolStripMenuItem.Checked")]
     public bool LogResults = false;
     [Setting(Input = "disableResultSortingToolStripMenuItem.Checked")]


### PR DESCRIPTION
Since we are usually only interested in the best solutions, we can gain performance by only keeping track of the best n solutions during pathfinding. For this, we added an option to the UI to configure the number of solutions that we want to get as a result.

The number of solutions barely has any impact on performance, but the lower the number of solutions, the faster the performance (theoretically).
Two options were removed (commented out) in the process, since they no longer make sense with this approach. (Disable Sorting, and Distinct Result End Times)

This approach results in a roughly 5x performance improvement for the example Only Dead End Restarts: False, Max Restart Count: 1 for SJ Beginner Lobby
Added benefit is, that we only use memory for the currently stored solutions, so there won't be any Out of Memory issues anymore.