### PR TITLE
Add Test New Connections Feature

### DIFF
--- a/AlgRunner.cs
+++ b/AlgRunner.cs
@@ -246,6 +246,7 @@ public class AlgRunner
         Console.WriteLine("Only Dead End Restarts: " + settings.RequiredRestarts);
         Console.WriteLine("Max Restart Count: " + settings.maxRestarts);
         Console.WriteLine("Number of Solutions: " + settings.topNSolutions);
+        Console.WriteLine("Find New Connections Mode: " + settings.newConnectionsMode);
 
         Console.WriteLine("\n-- Statistics --");
         Console.WriteLine("Routing took: " + timer.Elapsed);

--- a/MainForm.Designer.cs
+++ b/MainForm.Designer.cs
@@ -20,6 +20,8 @@ namespace RoboRouter
             base.Dispose(disposing);
         }
 
+        string NewConnectionsInputPlaceholder = "Format: 13-18, 0-20";
+
         #region Windows Form Designer generated code
 
         /// <summary>
@@ -42,7 +44,6 @@ namespace RoboRouter
             this.onlyRequiredRestartsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.maxRestartCountToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.topNSolutionsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.findNewConnectionsModeMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.lbl_startName = new System.Windows.Forms.Label();
             this.lbl_finishName = new System.Windows.Forms.Label();
             this.txt_startName = new System.Windows.Forms.TextBox();
@@ -50,6 +51,9 @@ namespace RoboRouter
             this.cbx_useTableInput = new System.Windows.Forms.CheckBox();
             this.txt_tableInput = new System.Windows.Forms.RichTextBox();
             this.lbl_tableInput = new System.Windows.Forms.Label();
+            this.cbx_newConnectionsMode = new System.Windows.Forms.CheckBox();
+            this.txt_newConnectionsInput = new System.Windows.Forms.TextBox();
+            this.lbl_newConnectionsInput = new System.Windows.Forms.Label();
             this.lbl_nameSeparators = new System.Windows.Forms.Label();
             this.txt_nameSeparators = new System.Windows.Forms.TextBox();
             this.btn_refresh = new System.Windows.Forms.Button();
@@ -61,7 +65,7 @@ namespace RoboRouter
             // 
             // txt_directory
             // 
-            this.txt_directory.Location = new System.Drawing.Point(151, 237);
+            this.txt_directory.Location = new System.Drawing.Point(151, 437);
             this.txt_directory.Name = "txt_directory";
             this.txt_directory.Size = new System.Drawing.Size(228, 23);
             this.txt_directory.TabIndex = 0;
@@ -69,7 +73,7 @@ namespace RoboRouter
             // lbl_directory
             // 
             this.lbl_directory.AutoSize = true;
-            this.lbl_directory.Location = new System.Drawing.Point(150, 219);
+            this.lbl_directory.Location = new System.Drawing.Point(150, 419);
             this.lbl_directory.Name = "lbl_directory";
             this.lbl_directory.Size = new System.Drawing.Size(98, 15);
             this.lbl_directory.TabIndex = 1;
@@ -151,8 +155,7 @@ namespace RoboRouter
             this.restartsToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.onlyRequiredRestartsToolStripMenuItem,
             this.maxRestartCountToolStripMenuItem,
-            this.topNSolutionsToolStripMenuItem,
-            this.findNewConnectionsModeMenuItem
+            this.topNSolutionsToolStripMenuItem
             });
             this.restartsToolStripMenuItem.Name = "restartsToolStripMenuItem";
             this.restartsToolStripMenuItem.Size = new System.Drawing.Size(60, 20);
@@ -176,13 +179,6 @@ namespace RoboRouter
             this.topNSolutionsToolStripMenuItem.Name = "topNSolutionsToolStripMenuItem";
             this.topNSolutionsToolStripMenuItem.Size = new System.Drawing.Size(196, 22);
             this.topNSolutionsToolStripMenuItem.Text = "Number of Solutions";
-            // 
-            // findNewConnectionsModeMenuItem
-            // 
-            this.findNewConnectionsModeMenuItem.Name = "findNewConnectionsModeMenuItem";
-            this.findNewConnectionsModeMenuItem.Size = new System.Drawing.Size(196, 22);
-            this.findNewConnectionsModeMenuItem.Text = "Find New Connections Mode";
-            this.findNewConnectionsModeMenuItem.Click += new System.EventHandler(this.findNewConnectionsModeMenuItem_Click);
             // 
             // lbl_startName
             // 
@@ -224,15 +220,15 @@ namespace RoboRouter
             this.cbx_useTableInput.Name = "cbx_useTableInput";
             this.cbx_useTableInput.Size = new System.Drawing.Size(106, 19);
             this.cbx_useTableInput.TabIndex = 11;
-            this.cbx_useTableInput.Text = "Use Table Input";
+            this.cbx_useTableInput.Text = "Use Table Input (Secondary method)";
             this.cbx_useTableInput.UseVisualStyleBackColor = true;
             this.cbx_useTableInput.CheckedChanged += new System.EventHandler(this.cbx_useTableInput_CheckedChanged);
             // 
             // txt_tableInput
             // 
-            this.txt_tableInput.Location = new System.Drawing.Point(150, 82);
+            this.txt_tableInput.Location = new System.Drawing.Point(150, 90);
             this.txt_tableInput.Name = "txt_tableInput";
-            this.txt_tableInput.Size = new System.Drawing.Size(231, 126);
+            this.txt_tableInput.Size = new System.Drawing.Size(666, 318);
             this.txt_tableInput.TabIndex = 12;
             this.txt_tableInput.Text = "";
             this.txt_tableInput.WordWrap = false;
@@ -240,11 +236,41 @@ namespace RoboRouter
             // lbl_tableInput
             // 
             this.lbl_tableInput.AutoSize = true;
-            this.lbl_tableInput.Location = new System.Drawing.Point(147, 59);
+            this.lbl_tableInput.Location = new System.Drawing.Point(147, 65);
             this.lbl_tableInput.Name = "lbl_tableInput";
             this.lbl_tableInput.Size = new System.Drawing.Size(197, 15);
             this.lbl_tableInput.TabIndex = 13;
-            this.lbl_tableInput.Text = "Table Input (Secondary use method)";
+            this.lbl_tableInput.Text = "Table Input";
+            // 
+            // cbx_newConnectionsMode
+            // 
+            this.cbx_newConnectionsMode.AutoSize = true;
+            this.cbx_newConnectionsMode.Location = new System.Drawing.Point(390, 35);
+            this.cbx_newConnectionsMode.Name = "cbx_newConnectionsMode";
+            this.cbx_newConnectionsMode.Size = new System.Drawing.Size(106, 19);
+            this.cbx_newConnectionsMode.TabIndex = 19;
+            this.cbx_newConnectionsMode.Text = "Test New Connections";
+            this.cbx_newConnectionsMode.UseVisualStyleBackColor = true;
+            this.cbx_newConnectionsMode.CheckedChanged += new System.EventHandler(this.cbx_newConnectionsMode_CheckedChanged);
+            // 
+            // txt_newConnectionsInput
+            // 
+            this.txt_newConnectionsInput.Location = new System.Drawing.Point(465, 62);
+            this.txt_newConnectionsInput.Name = "txt_newConnectionsInput";
+            this.txt_newConnectionsInput.Size = new System.Drawing.Size(350, 23);
+            this.txt_newConnectionsInput.TabIndex = 21;
+            this.txt_newConnectionsInput.Enter += new System.EventHandler(this.txt_newConnectionsInput_Enter);
+            this.txt_newConnectionsInput.Leave += new System.EventHandler(this.txt_newConnectionsInput_Leave);
+            this.txt_newConnectionsInput.Text = "Format: 13-18, 0-20";
+            // 
+            // lbl_newConnectionsInput
+            // 
+            this.lbl_newConnectionsInput.AutoSize = true;
+            this.lbl_newConnectionsInput.Location = new System.Drawing.Point(387, 65);
+            this.lbl_newConnectionsInput.Name = "lbl_newConnectionsInput";
+            this.lbl_newConnectionsInput.Size = new System.Drawing.Size(197, 15);
+            this.lbl_newConnectionsInput.TabIndex = 20;
+            this.lbl_newConnectionsInput.Text = "Connections";
             // 
             // lbl_nameSeparators
             // 
@@ -264,7 +290,7 @@ namespace RoboRouter
             // 
             // btn_refresh
             // 
-            this.btn_refresh.Location = new System.Drawing.Point(150, 271);
+            this.btn_refresh.Location = new System.Drawing.Point(390, 419);
             this.btn_refresh.Name = "btn_refresh";
             this.btn_refresh.Size = new System.Drawing.Size(111, 41);
             this.btn_refresh.TabIndex = 16;
@@ -274,7 +300,7 @@ namespace RoboRouter
             // 
             // num_restartPenalty
             // 
-            this.num_restartPenalty.Location = new System.Drawing.Point(273, 288);
+            this.num_restartPenalty.Location = new System.Drawing.Point(513, 436);
             this.num_restartPenalty.Maximum = new decimal(new int[] {
             10000,
             0,
@@ -287,7 +313,7 @@ namespace RoboRouter
             // lbl_restartPenalty
             // 
             this.lbl_restartPenalty.AutoSize = true;
-            this.lbl_restartPenalty.Location = new System.Drawing.Point(273, 270);
+            this.lbl_restartPenalty.Location = new System.Drawing.Point(513, 418);
             this.lbl_restartPenalty.Name = "lbl_restartPenalty";
             this.lbl_restartPenalty.Size = new System.Drawing.Size(85, 15);
             this.lbl_restartPenalty.TabIndex = 18;
@@ -298,7 +324,7 @@ namespace RoboRouter
             this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.BackColor = System.Drawing.Color.Silver;
-            this.ClientSize = new System.Drawing.Size(394, 325);
+            this.ClientSize = new System.Drawing.Size(830, 474);
             this.Controls.Add(this.lbl_restartPenalty);
             this.Controls.Add(this.num_restartPenalty);
             this.Controls.Add(this.btn_refresh);
@@ -307,6 +333,9 @@ namespace RoboRouter
             this.Controls.Add(this.lbl_tableInput);
             this.Controls.Add(this.txt_tableInput);
             this.Controls.Add(this.cbx_useTableInput);
+            this.Controls.Add(this.lbl_newConnectionsInput);
+            this.Controls.Add(this.txt_newConnectionsInput);
+            this.Controls.Add(this.cbx_newConnectionsMode);
             this.Controls.Add(this.txt_finishName);
             this.Controls.Add(this.txt_startName);
             this.Controls.Add(this.lbl_finishName);
@@ -346,6 +375,9 @@ namespace RoboRouter
         private System.Windows.Forms.CheckBox cbx_useTableInput;
         private System.Windows.Forms.RichTextBox txt_tableInput;
         private System.Windows.Forms.Label lbl_tableInput;
+        private System.Windows.Forms.CheckBox cbx_newConnectionsMode;
+        private System.Windows.Forms.TextBox txt_newConnectionsInput;
+        private System.Windows.Forms.Label lbl_newConnectionsInput;
         private System.Windows.Forms.Label lbl_nameSeparators;
         private System.Windows.Forms.TextBox txt_nameSeparators;
         private System.Windows.Forms.Button btn_refresh;
@@ -354,7 +386,6 @@ namespace RoboRouter
         private System.Windows.Forms.ToolStripMenuItem onlyRequiredRestartsToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem maxRestartCountToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem topNSolutionsToolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem findNewConnectionsModeMenuItem;
         private System.Windows.Forms.NumericUpDown num_restartPenalty;
         private System.Windows.Forms.Label lbl_restartPenalty;
         //private System.Windows.Forms.ToolStripMenuItem disableResultSortingToolStripMenuItem;

--- a/MainForm.Designer.cs
+++ b/MainForm.Designer.cs
@@ -42,6 +42,7 @@ namespace RoboRouter
             this.onlyRequiredRestartsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.maxRestartCountToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.topNSolutionsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.findNewConnectionsModeMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.lbl_startName = new System.Windows.Forms.Label();
             this.lbl_finishName = new System.Windows.Forms.Label();
             this.txt_startName = new System.Windows.Forms.TextBox();
@@ -150,7 +151,8 @@ namespace RoboRouter
             this.restartsToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.onlyRequiredRestartsToolStripMenuItem,
             this.maxRestartCountToolStripMenuItem,
-            this.topNSolutionsToolStripMenuItem
+            this.topNSolutionsToolStripMenuItem,
+            this.findNewConnectionsModeMenuItem
             });
             this.restartsToolStripMenuItem.Name = "restartsToolStripMenuItem";
             this.restartsToolStripMenuItem.Size = new System.Drawing.Size(60, 20);
@@ -174,6 +176,13 @@ namespace RoboRouter
             this.topNSolutionsToolStripMenuItem.Name = "topNSolutionsToolStripMenuItem";
             this.topNSolutionsToolStripMenuItem.Size = new System.Drawing.Size(196, 22);
             this.topNSolutionsToolStripMenuItem.Text = "Number of Solutions";
+            // 
+            // findNewConnectionsModeMenuItem
+            // 
+            this.findNewConnectionsModeMenuItem.Name = "findNewConnectionsModeMenuItem";
+            this.findNewConnectionsModeMenuItem.Size = new System.Drawing.Size(196, 22);
+            this.findNewConnectionsModeMenuItem.Text = "Find New Connections Mode";
+            this.findNewConnectionsModeMenuItem.Click += new System.EventHandler(this.findNewConnectionsModeMenuItem_Click);
             // 
             // lbl_startName
             // 
@@ -345,6 +354,7 @@ namespace RoboRouter
         private System.Windows.Forms.ToolStripMenuItem onlyRequiredRestartsToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem maxRestartCountToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem topNSolutionsToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem findNewConnectionsModeMenuItem;
         private System.Windows.Forms.NumericUpDown num_restartPenalty;
         private System.Windows.Forms.Label lbl_restartPenalty;
         //private System.Windows.Forms.ToolStripMenuItem disableResultSortingToolStripMenuItem;

--- a/MainForm.cs
+++ b/MainForm.cs
@@ -312,6 +312,7 @@ public partial class MainForm : Form
 
     private void onlyRequiredRestartsToolStripMenuItem_Click(object sender, EventArgs e) => onlyRequiredRestartsToolStripMenuItem.Checked ^= true;
     //private void distinctResultEndTimesToolStripMenuItem_Click(object sender, EventArgs e) => distinctResultEndTimesToolStripMenuItem.Checked ^= true;
+    private void findNewConnectionsModeMenuItem_Click(object sender, EventArgs e) => findNewConnectionsModeMenuItem.Checked ^= true;
     private void logResultsToTextFilesToolStripMenuItem_Click(object sender, EventArgs e) => logResultsToTextFilesToolStripMenuItem.Checked ^= true;
     //private void disableResultSortingToolStripMenuItem_Click(object sender, EventArgs e) => disableResultSortingToolStripMenuItem.Checked ^= true;
 

--- a/MainForm.cs
+++ b/MainForm.cs
@@ -32,6 +32,11 @@ public partial class MainForm : Form
         UpdateStartAndEnd(false);
         UpdateAccess();
 
+        if (txt_newConnectionsInput.Text == NewConnectionsInputPlaceholder)
+        {
+            txt_newConnectionsInput.ForeColor = System.Drawing.Color.Gray;
+        }
+
         Output.Initialize();
         Select();
         txt_directory.MouseEnter += (_, _) => mouseOnDirBox = true;
@@ -233,9 +238,20 @@ public partial class MainForm : Form
 
     public void UpdateAccess()
     {
-        foreach (var ctrl in new Control[] { btn_fetchTimes, txt_nameSeparators, txt_startName, txt_finishName, btn_refresh, num_restartPenalty, txt_directory })
+        foreach (var ctrl in new Control[] { btn_fetchTimes, txt_nameSeparators, txt_startName, txt_finishName, btn_refresh, num_restartPenalty, txt_directory }) {
             ctrl.Enabled = !cbx_useTableInput.Checked;
+        }
+
+        foreach (var ctrl in new Control[] { cbx_newConnectionsMode, txt_newConnectionsInput }) {
+            ctrl.Enabled = cbx_useTableInput.Checked;
+        }
+
+        if (!cbx_useTableInput.Checked) {
+            cbx_newConnectionsMode.Checked = false;
+        }
+
         txt_tableInput.Enabled = cbx_useTableInput.Checked;
+        txt_newConnectionsInput.Enabled = cbx_newConnectionsMode.Checked;
     }
 
     NumMenuItem maxRestarts;
@@ -267,6 +283,24 @@ public partial class MainForm : Form
         using var file = new FileStream("settings.xml", FileMode.OpenOrCreate);
         file.SetLength(0);
         new XmlSerializer(typeof(Settings)).Serialize(file, settings);
+    }
+
+    private void txt_newConnectionsInput_Enter(object sender, EventArgs e)
+    {
+        if (txt_newConnectionsInput.Text == NewConnectionsInputPlaceholder)
+        {
+            txt_newConnectionsInput.Text = "";
+        }
+        txt_newConnectionsInput.ForeColor = System.Drawing.Color.Black;
+    }
+
+    private void txt_newConnectionsInput_Leave(object sender, EventArgs e)
+    {
+        if (string.IsNullOrEmpty(txt_newConnectionsInput.Text))
+        {
+            txt_newConnectionsInput.Text = NewConnectionsInputPlaceholder;
+            txt_newConnectionsInput.ForeColor = System.Drawing.Color.Gray;
+        }
     }
 
     private void btn_route_Click(object sender, EventArgs e)
@@ -316,11 +350,11 @@ public partial class MainForm : Form
 
     private void onlyRequiredRestartsToolStripMenuItem_Click(object sender, EventArgs e) => onlyRequiredRestartsToolStripMenuItem.Checked ^= true;
     //private void distinctResultEndTimesToolStripMenuItem_Click(object sender, EventArgs e) => distinctResultEndTimesToolStripMenuItem.Checked ^= true;
-    private void findNewConnectionsModeMenuItem_Click(object sender, EventArgs e) => findNewConnectionsModeMenuItem.Checked ^= true;
     private void logResultsToTextFilesToolStripMenuItem_Click(object sender, EventArgs e) => logResultsToTextFilesToolStripMenuItem.Checked ^= true;
     //private void disableResultSortingToolStripMenuItem_Click(object sender, EventArgs e) => disableResultSortingToolStripMenuItem.Checked ^= true;
 
     private void cbx_useTableInput_CheckedChanged(object sender, EventArgs e) => UpdateAccess();
+    private void cbx_newConnectionsMode_CheckedChanged(object sender, EventArgs e) => UpdateAccess();
 
     private void helpToolStripMenuItem_Click(object sender, EventArgs e)
     {

--- a/MainForm.cs
+++ b/MainForm.cs
@@ -160,7 +160,7 @@ public partial class MainForm : Form
                     end = (j + 1).ToString(),
                     time = time
                 })
-            ).SelectMany(arr => arr.Where(f => f.time < 2500 && f.start != f.end)).ToArray();
+            ).SelectMany(arr => arr.Where(f => f.time < 10000 && f.start != f.end)).ToArray();
 
             return true;
         }
@@ -289,7 +289,11 @@ public partial class MainForm : Form
                 oldRunner.stillRunning = false;
             oldRunner = new AlgRunner(this);
             Console.WriteLine("Loading...");
-            new Thread(oldRunner.SolveLobby).Start();
+            if (settings.newConnectionsMode) {
+                new Thread(oldRunner.FindNewConnections).Start();
+            } else {
+                new Thread(oldRunner.SolveLobby).Start();
+            }
         }
     }
 

--- a/RandomClasses.cs
+++ b/RandomClasses.cs
@@ -38,3 +38,25 @@ public struct PlaceInfo
 
     public int FramesTo(int place) => times[Array.IndexOf(targets, place)];
 }
+
+public struct Solution {
+    public int[] path;
+    public int time;
+
+    public Solution(int[] _path, int _time) {
+        path = _path;
+        time = _time;
+    }
+}
+
+public struct ConnectionResult {
+    public string connectionName;
+    public string parsedSol;
+    public int timeNeeded;
+
+    public ConnectionResult(string _connectionName, string _parsedSol, int _timeNeeded) {
+        connectionName = _connectionName;
+        parsedSol = _parsedSol;
+        timeNeeded = _timeNeeded;
+    }
+}

--- a/RandomClasses.cs
+++ b/RandomClasses.cs
@@ -60,3 +60,13 @@ public struct ConnectionResult {
         timeNeeded = _timeNeeded;
     }
 }
+
+public struct Connection {
+    public int start;
+    public int end;
+
+    public Connection(int _start, int _end) {
+        start = _start;
+        end = _end;
+    }
+}

--- a/RoboRouter.csproj
+++ b/RoboRouter.csproj
@@ -7,7 +7,7 @@
     <UseWindowsForms>true</UseWindowsForms>
     <ImplicitUsings>enable</ImplicitUsings>
     <PublishSingleFile>true</PublishSingleFile>
-    <!-- <Optimize>true</Optimize> -->
+    <Optimize>true</Optimize>
   </PropertyGroup>
 
 </Project>

--- a/RoboRouter.csproj
+++ b/RoboRouter.csproj
@@ -7,7 +7,7 @@
     <UseWindowsForms>true</UseWindowsForms>
     <ImplicitUsings>enable</ImplicitUsings>
     <PublishSingleFile>true</PublishSingleFile>
-    <Optimize>true</Optimize>
+    <!-- <Optimize>true</Optimize> -->
   </PropertyGroup>
 
 </Project>

--- a/Settings.cs
+++ b/Settings.cs
@@ -15,6 +15,11 @@ public class Settings
     [Setting(Input = "txt_tableInput.Text")]
     public string? TableInput;
 
+    [Setting(Input = "cbx_newConnectionsMode.Checked")]
+    public bool newConnectionsMode = false;
+    [Setting(Input = "txt_newConnectionsInput.Text")]
+    public string NewConnectionsInput = "Format: 13-18, 0-20";
+
     [Setting(Input = "num_restartPenalty.Value")]
     public int restartPenalty = 190;
     [Setting(Input = "onlyRequiredRestartsToolStripMenuItem.Checked")]
@@ -23,8 +28,6 @@ public class Settings
     public int maxRestarts = -1;
     [Setting(Input = "topNSolutions.Value")]
     public int topNSolutions = 100;
-    [Setting(Input = "findNewConnectionsModeMenuItem.Checked")]
-    public bool newConnectionsMode = false;
 
     // [Setting(Input = "distinctResultEndTimesToolStripMenuItem.Checked")]
     // public bool DistinctTimings = true;

--- a/Settings.cs
+++ b/Settings.cs
@@ -23,6 +23,8 @@ public class Settings
     public int maxRestarts = -1;
     [Setting(Input = "topNSolutions.Value")]
     public int topNSolutions = 100;
+    [Setting(Input = "findNewConnectionsModeMenuItem.Checked")]
+    public bool newConnectionsMode = false;
 
     // [Setting(Input = "distinctResultEndTimesToolStripMenuItem.Checked")]
     // public bool DistinctTimings = true;

--- a/help.txt
+++ b/help.txt
@@ -1,0 +1,39 @@
+
+How to get started:
+
+1: Click the 'Lobby TAS Folder' text box and select the folder that contains all of the lobby files you want to route.
+   Note that every TAS file in the folder has to be a lobby file, and that it will find files in
+   branching directories of the given folder as well.
+
+2: Adjust the 'Restart Penalty' value if you need to. It's the same as how long it takes to gain control when you enter the lobby.
+
+3: Try clicking the 'Run Router' button. It might work already, but if it doesn't,
+   it will give you feedback in what needs to be fixed.
+
+4: You can disable 'Only Dead End Restarts' in the 'Restarts' dropdown menu to route the lobby more thoroughly.
+   This allows many many more mostly useless routes and might make very big lobbies take long to compute.
+
+
+
+Table input is the secondary way to use the pathfinding algorithm.
+It's only useful if you're already using something like a spreadsheet to keep track of lobby TASing progress.
+In a routing table, the Y axis is the start location and the X axis is the target location.
+A table looks something like this:
+
+[0,259,60000,60000,60000,60000,60000,60000,60000,60000,116,147,60000,128,4],
+[190,0,218,60000,60000,60000,60000,60000,60000,60000,60000,60000,60000,236,162],
+[190,177,0,241,60000,60000,60000,60000,60000,60000,60000,60000,60000,60000,60000],
+[190,60000,285,0,197,60000,60000,60000,60000,60000,60000,60000,60000,60000,60000],
+[190,60000,60000,249,0,232,60000,60000,60000,60000,60000,60000,60000,60000,60000],
+[190,60000,60000,60000,222,0,247,60000,60000,60000,60000,60000,206,60000,60000],
+[190,60000,60000,60000,60000,345,0,233,60000,60000,94,60000,133,60000,60000],
+[190,60000,60000,60000,60000,60000,213,0,164,185,152,60000,60000,60000,60000],
+[190,60000,60000,60000,60000,60000,60000,257,0,282,336,60000,60000,60000,60000],
+[190,60000,60000,60000,60000,60000,60000,296,329,0,317,337,60000,60000,60000],
+[190,60000,60000,60000,60000,60000,196,215,262,218,0,139,193,60000,153],
+[190,60000,60000,60000,60000,60000,60000,60000,60000,199,119,0,60000,60000,167],
+[190,60000,60000,60000,60000,312,128,60000,60000,60000,169,60000,0,60000,60000],
+[190,269,60000,60000,60000,60000,60000,60000,60000,60000,181,207,60000,0,66],
+[0,60000,60000,60000,60000,60000,60000,60000,60000,60000,60000,60000,60000,60000,0]
+
+Exact formatting of the table does not matter. It only looks for the separate numbers per line.


### PR DESCRIPTION
New option when using Table Input to test potentially useful connections that arent part of the drafted files yet.
Works by assuming the connection in question exists and forcing the algorithm to take that connection in every route. Then, the difference between the optimal existing solution in the original input and the "theoretical" solution with the forced connection tells us, how fast the connection has to be in order to be worth it.