### PR TITLE
Allow the start file to not be index 0

### DIFF
--- a/AlgRunner.cs
+++ b/AlgRunner.cs
@@ -429,7 +429,7 @@ public class AlgRunner
         }
 
         // Determine lowest incoming time for each node
-        lowestTimes[0] = 0;
+        lowestTimes[start] = 0;
         for (int n = 0; n < nodes.Count(); n++) {
             for (int t = 0; t < nodes[n].targets.Count(); t++) {
                 if (lowestTimes[nodes[n].targets[t]] > nodes[n].times[t]) {

--- a/AlgRunner.cs
+++ b/AlgRunner.cs
@@ -137,7 +137,7 @@ public class AlgRunner
         }
 
         // Determine lowest incoming time for each node
-        lowestTimes[0] = 0;
+        lowestTimes[start] = 0;
         for (int n = 0; n < nodes.Count(); n++) {
             for (int t = 0; t < nodes[n].targets.Count(); t++) {
                 if (lowestTimes[nodes[n].targets[t]] > nodes[n].times[t]) {


### PR DESCRIPTION
During lowest times calculations the Start file is assumed to be at index 0, use the previously calculated index instead, this fixes possible issues with file input mode not working